### PR TITLE
Fixed minor syntax error

### DIFF
--- a/lv_fs_fatfs.c
+++ b/lv_fs_fatfs.c
@@ -208,7 +208,7 @@ static void * fs_dir_open (lv_fs_drv_t * drv, const char *path)
     if(d == NULL) return NULL;
 
     FRESULT res = f_opendir(d, path);
-    if(res !== FR_OK) {
+    if(res != FR_OK) {
         lv_mem_free(d);
         d = NULL;
     }


### PR DESCRIPTION
The following line gave a syntax error with a C++ compiler
`if(res !== FR_OK)`